### PR TITLE
linked each proudct to the prouct info page

### DIFF
--- a/views/product_list.pug
+++ b/views/product_list.pug
@@ -10,6 +10,7 @@ block content
                     h3 $#{product.price}
                     h6 #{product.description}
                     h3 available: #{product.quantity_avail}
+                    a(class="seemore" href="/products/"+product.id) see more
                     <br>
             
                 


### PR DESCRIPTION
This links a product to it's designated product route. 

to test: click on products, then click on 'see more', then, if it takes you to the product route, give this pull request a thumbs up so I can merge it. 